### PR TITLE
Fix compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+        fail-fast: false
+        matrix:
+          os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build PlatformIO Project
+        run: pio run

--- a/lib/LoRaCode/LoRaCode.cpp
+++ b/lib/LoRaCode/LoRaCode.cpp
@@ -35,7 +35,7 @@
 #include <Arduino.h>
 #include <Battery.h>
 #elif defined(ARDUINO_ARCH_ESP8266) | defined(ESP32)
-#include <ESP.h>
+#include <Esp.h>
 #elif defined(__MKL26Z64__)
 #include <Arduino.h>
 #else

--- a/lib/Time/DateStrings.cpp
+++ b/lib/Time/DateStrings.cpp
@@ -20,7 +20,7 @@
 #define strcpy_P(dest, src) strcpy((dest), (src))
 #endif
 #include <string.h> // for strcpy_P or strcpy
-#include "Time.h"
+#include "TimeLib.h"
  
 // the short strings for each day or month must be exactly dt_SHORT_STR_LEN
 #define dt_SHORT_STR_LEN  3 // the length of short strings

--- a/lib/Time/Time.cpp
+++ b/lib/Time/Time.cpp
@@ -33,7 +33,7 @@
 #include <WProgram.h> 
 #endif
 
-#include "Time.h"
+#include "TimeLib.h"
 
 static tmElements_t tm;          // a cache of time elements
 static time_t cacheTime;   // the time the cache was updated

--- a/lib/Time/Time.h
+++ b/lib/Time/Time.h
@@ -1,1 +1,0 @@
-#include "TimeLib.h"

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,10 +9,10 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp-wrover-kit]
-platform = espressif32
+platform = espressif32@6.4.0
 board = esp-wrover-kit
 framework = arduino
-
+; uncomment this if you want to upload via OTA (WiFI). Change IP to the IP of the ESP32 as needed.
 ;upload_protocol = espota
 ;upload_port = 192.168.0.115
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,13 +13,12 @@ platform = espressif32
 board = esp-wrover-kit
 framework = arduino
 
-upload_protocol = espota
-upload_port = 192.168.0.115
+;upload_protocol = espota
+;upload_port = 192.168.0.115
 
 ; upload_port = COM10
 ; upload_speed = 921600
 build_flags =
-	${common.build_flags}
 	-DBOARD_HAS_PSRAM=TRUE
 	-mfix-esp32-psram-cache-issue
 	-DLED_STAT2=15


### PR DESCRIPTION
Fixes compilation on latest PlatformIO version and Espressif32 Arduino core version
* deletes `Time.h` to not conflict with `time.h` from the compiler, fixes compile on Windows and Mac
* Fixes up wrong include name (`ESP.h` -> `Esp.h`), fixes compile on Linux
* Pins `espressif32` platform version at current latest to prevent future problems
* Changes default upload protocol to use esptool.py (aka Serial / USB cable)
* Adds (free) Github Actions as CI for verifiable builds